### PR TITLE
kernel 5.17 renames PDE_DATA -> pde_data

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -97,24 +97,7 @@ static char proto_name[]="proto";
 static char debug_name[]="debug";
 
 
-#if 1
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
 #define PROC_REMOVE(pde,net) proc_remove(pde)
-#else
-
-#define PROC_REMOVE(pde,net) proc_net_remove(net,dir_name)
-
-/* backport from 3.10 */
-static inline struct inode *file_inode(struct file *f)
-{
-	return f->f_path.dentry->d_inode;
-}
-static inline void *PDE_DATA(const struct inode *inode)
-{
-	return PROC_I(inode)->pde->data;
-}
-#endif
-#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 static inline struct net *xt_net(const struct xt_action_param *par)

--- a/ndpi-netfilter/src/ndpi_main_common.h
+++ b/ndpi-netfilter/src/ndpi_main_common.h
@@ -98,3 +98,7 @@ static inline void getnstimeofday64(struct timespec64 *ts) {
 	ktime_get_real_ts64(ts);
 }
 #endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#define pde_data(inode) PDE_DATA(inode)
+#endif

--- a/ndpi-netfilter/src/ndpi_proc_flow.c
+++ b/ndpi-netfilter/src/ndpi_proc_flow.c
@@ -326,7 +326,7 @@ ssize_t ndpi_dump_acct_info(struct ndpi_net *n,
 ssize_t nflow_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	if(n->acc_last_op != 1) { // seek 0 after write command
 		n->acc_last_op = 1;
 		nflow_proc_read_start(n);
@@ -385,7 +385,7 @@ static int parse_ndpi_flow(struct ndpi_net *n,char *buf)
 }
 
 int nflow_proc_open(struct inode *inode, struct file *file) {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 
 	if(!ndpi_enable_flow) return -EINVAL;
 
@@ -399,7 +399,7 @@ int nflow_proc_open(struct inode *inode, struct file *file) {
 
 int nflow_proc_close(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	if(!ndpi_enable_flow) return -EINVAL;
 	generic_proc_close(n,parse_ndpi_flow,W_BUF_FLOW);
 	if(flow_read_debug)
@@ -414,17 +414,17 @@ ssize_t
 nflow_proc_write(struct file *file, const char __user *buffer,
 		                     size_t length, loff_t *loff)
 {
-struct ndpi_net *n = PDE_DATA(file_inode(file));
+struct ndpi_net *n = pde_data(file_inode(file));
 	if(!ndpi_enable_flow) return -EINVAL;
 	if(n->flow_l) return -EINVAL; // Reading in progress!
 	n->acc_last_op = 2;
-	return generic_proc_write(PDE_DATA(file_inode(file)), buffer, length, loff,
+	return generic_proc_write(pde_data(file_inode(file)), buffer, length, loff,
 				  parse_ndpi_flow, 4060 , W_BUF_FLOW);
 }
 
 loff_t nflow_proc_llseek(struct file *file, loff_t offset, int whence) {
 	if(whence == SEEK_SET) {
-		struct ndpi_net *n = PDE_DATA(file_inode(file));
+		struct ndpi_net *n = pde_data(file_inode(file));
 		if(offset == 0) {
 			if(flow_read_debug)
 				pr_info("%s:%s seek start\n", __func__,n->ns_name);

--- a/ndpi-netfilter/src/ndpi_proc_hostdef.c
+++ b/ndpi-netfilter/src/ndpi_proc_hostdef.c
@@ -21,7 +21,7 @@
 
 int n_hostdef_proc_open(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	int ret = 0;
 
 	mutex_lock(&n->host_lock);
@@ -66,7 +66,7 @@ do {
 ssize_t n_hostdef_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	char lbuf[256+32],*host;
 	const char *t_proto;
 	str_collect_t *ph;
@@ -173,7 +173,7 @@ ssize_t n_hostdef_proc_read(struct file *file, char __user *buf,
 
 int n_hostdef_proc_close(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	ndpi_mod_str_t *nstr = n->ndpi_struct;
 
 	generic_proc_close(n,parse_ndpi_hostdef,W_BUF_HOST);
@@ -210,7 +210,7 @@ ssize_t
 n_hostdef_proc_write(struct file *file, const char __user *buffer,
                      size_t length, loff_t *loff)
 {
-	return generic_proc_write(PDE_DATA(file_inode(file)), buffer, length, loff,
+	return generic_proc_write(pde_data(file_inode(file)), buffer, length, loff,
 			parse_ndpi_hostdef, 4060, W_BUF_HOST);
 }
 

--- a/ndpi-netfilter/src/ndpi_proc_info.c
+++ b/ndpi-netfilter/src/ndpi_proc_info.c
@@ -130,21 +130,21 @@ ssize_t _ninfo_proc_read(struct ndpi_net *n, char __user *buf,
 ssize_t ninfo_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-return _ninfo_proc_read(PDE_DATA(file_inode(file)),buf,count,ppos,AF_INET);
+return _ninfo_proc_read(pde_data(file_inode(file)),buf,count,ppos,AF_INET);
 }
 
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
 ssize_t ninfo6_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-return _ninfo_proc_read(PDE_DATA(file_inode(file)),buf,count,ppos,AF_INET6);
+return _ninfo_proc_read(pde_data(file_inode(file)),buf,count,ppos,AF_INET6);
 }
 #endif
 
 ssize_t ninfo_proc_write(struct file *file, const char __user *buffer,
                      size_t length, loff_t *loff)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	char buf[32];
 	int idx;
 
@@ -163,7 +163,7 @@ ssize_t ninfo_proc_write(struct file *file, const char __user *buffer,
 ssize_t nann_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
         struct ndpi_detection_module_struct *ndpi_struct = n->ndpi_struct;
 	struct bt_announce *b = ndpi_struct->bt_ann;
 	int  bt_len = ndpi_struct->bt_ann_len;
@@ -198,7 +198,7 @@ ssize_t nann_proc_read(struct file *file, char __user *buf,
 ssize_t nproto_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	char lbuf[128];
 	char c_buf[32];
 	int i,l,p,ro;
@@ -262,7 +262,7 @@ ssize_t nproto_proc_read(struct file *file, char __user *buf,
 
 int nproto_proc_close(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	generic_proc_close(n,parse_ndpi_proto,W_BUF_PROTO);
         return 0;
 }
@@ -271,7 +271,7 @@ ssize_t
 nproto_proc_write(struct file *file, const char __user *buffer,
                      size_t length, loff_t *loff)
 {
-	return generic_proc_write(PDE_DATA(file_inode(file)), buffer, length, loff,
+	return generic_proc_write(pde_data(file_inode(file)), buffer, length, loff,
 			parse_ndpi_proto, 256, W_BUF_PROTO);
 }
 

--- a/ndpi-netfilter/src/ndpi_proc_info.c
+++ b/ndpi-netfilter/src/ndpi_proc_info.c
@@ -305,7 +305,7 @@ ssize_t ndebug_proc_read(struct file *file, char __user *buf,
 }
 int ndebug_proc_close(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	generic_proc_close(n,parse_ndpi_debug,W_BUF_PROTO);
         return 0;
 }
@@ -314,7 +314,7 @@ ssize_t
 ndebug_proc_write(struct file *file, const char __user *buffer,
                      size_t length, loff_t *loff)
 {
-	return generic_proc_write(PDE_DATA(file_inode(file)), buffer, length, loff,
+	return generic_proc_write(pde_data(file_inode(file)), buffer, length, loff,
 			parse_ndpi_debug, 256, W_BUF_PROTO);
 }
 

--- a/ndpi-netfilter/src/ndpi_proc_ipdef.c
+++ b/ndpi-netfilter/src/ndpi_proc_ipdef.c
@@ -25,7 +25,7 @@ int n_ipdef_proc_open(struct inode *inode, struct file *file)
 
 int n_ipdef_proc_close(struct inode *inode, struct file *file)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	generic_proc_close(n,parse_ndpi_ipdef,W_BUF_IP);
         return 0;
 }
@@ -34,14 +34,14 @@ ssize_t
 n_ipdef_proc_write(struct file *file, const char __user *buffer,
                      size_t length, loff_t *loff)
 {
-	return generic_proc_write(PDE_DATA(file_inode(file)), buffer, length, loff,
+	return generic_proc_write(pde_data(file_inode(file)), buffer, length, loff,
 			parse_ndpi_ipdef, 4060 , W_BUF_IP);
 }
 
 ssize_t n_ipdef_proc_read(struct file *file, char __user *buf,
                               size_t count, loff_t *ppos)
 {
-        struct ndpi_net *n = PDE_DATA(file_inode(file));
+        struct ndpi_net *n = pde_data(file_inode(file));
 	ndpi_patricia_tree_t *pt;
 	ndpi_prefix_t *px;
 	ndpi_patricia_node_t *Xstack[PATRICIA_MAXBITS+1], **Xsp, *node;


### PR DESCRIPTION
Kernel 5.17 has some notes that there is a new wrapper function "pde_data()" to hide access to PDE_DATA

However, previously we seemed to introduce this function ourselves, this leads to a rather nasty nested #IF

I suspect we can do better to make the nested nature of the test clearer, but this fixes that compilation error on 5.17