### PR TITLE
Fix bracing issue of commit d238ff6

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -1678,7 +1678,7 @@ ndpi_mt(const struct sk_buff *skb, struct xt_action_param *par)
 			    u_int8_t proto_guessed;
 			    ndpi_protocol p_old = proto;
 			    proto = ndpi_detection_giveup(n->ndpi_struct, flow, 1, &proto_guessed);
-			    if(_DBG_TRACE_DPI)
+			    if(_DBG_TRACE_DPI) {
 			        if( p_old.app_protocol != proto.app_protocol ||
 				    p_old.master_protocol != proto.master_protocol ||
 				    confidence != flow->confidence)


### PR DESCRIPTION
The brace in commit 6238ff6 is not paired, resulting in build failure of kernel module.

https://github.com/vel21ripn/nDPI/blob/d238ff6ad1715a640df62c7b47373293c8c136bd/ndpi-netfilter/src/main.c#L1681-L1689