### PR TITLE
added risk proc/flow

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -1642,6 +1642,7 @@ ndpi_mt(const struct sk_buff *skb, struct xt_action_param *par)
 		ct_ndpi->proto.app_protocol = proto.app_protocol;
 		ct_ndpi->proto.master_protocol = proto.master_protocol;
 		c_proto->proto = pack_proto(proto);
+		ct_ndpi->risk = flow->risk;
 
 		ndpi_host_info(ct_ndpi);
 
@@ -1698,6 +1699,7 @@ ndpi_mt(const struct sk_buff *skb, struct xt_action_param *par)
 			    ct_ndpi->proto.master_protocol = proto.master_protocol;
 			    ct_ndpi->confidence = confidence = flow->confidence;
 			    c_proto->proto = pack_proto(proto);
+				ct_ndpi->risk = flow->risk;
 			}
 		    	if(_DBG_TRACE_DDONE)
 		    	    packet_trace(skb,ct,ct_ndpi,"dpi_done ","%s %d, free flow",

--- a/ndpi-netfilter/src/ndpi_main_netfilter.h
+++ b/ndpi-netfilter/src/ndpi_main_netfilter.h
@@ -200,6 +200,7 @@ struct nf_ct_ext_ndpi {
 	uint8_t			l4_proto;	// 1
 	uint8_t			confidence;	// 1
 #endif
+	uint64_t		risk;
 	uint16_t		ja3s,ja3c,tlsv,tlsfp;
 						// offset+1 in flow_opt
 

--- a/ndpi-netfilter/src/ndpi_proc_flow.c
+++ b/ndpi-netfilter/src/ndpi_proc_flow.c
@@ -341,6 +341,8 @@ ssize_t ndpi_dump_acct_info(struct ndpi_net *n,
 	    }
 	  }
 	}
+	
+	l += snprintf(&buf[l],buflen-l," R=%llu",ct->risk);
 	buf[l++] = '\n';
 	buf[l] = 0;
 	n->str_buf_len = l; 


### PR DESCRIPTION
added unsigned 64 bit integer to nf_ct_ext_ndpi struct
added copy (exactly as confidence level is done) in "ndpi_mt" function from the ndpi_flow struct, 
added snprintf to so that the risk is displayed when cat on proc

User can read the proc file and analyze the integer to find which bit is set 