### PR TITLE
Fix 'echo unknown 10040 >/proc/net/xt_ndpi/proto' command failed

### DIFF
--- a/ndpi-netfilter/src/ndpi_proc_parsers.c
+++ b/ndpi-netfilter/src/ndpi_proc_parsers.c
@@ -775,11 +775,7 @@ int parse_ndpi_proto(struct ndpi_net *n,char *cmd) {
 		    if(kstrtoint(hid,16,&id)) {
 			id = -1;
 			id = ndpi_get_proto_by_name(n->ndpi_struct,hid);
-			if(id == NDPI_PROTOCOL_UNKNOWN && !(all || any)) {
-				pr_err("NDPI: '%s' unknown protocol or not hexID\n",hid);
-				return 1;
-			}
-		    } else {
+            } else {
 			if(id < 0 || id >= NDPI_NUM_BITS) {
 				pr_err("NDPI: bad id %d\n",id);
 				id = -1;


### PR DESCRIPTION
Hi Vitaly Lavrov :
when I execute this command ''echo unknown 10040 >/proc/net/xt_ndpi/proto" failed just like you wrote in file ndpi-netfilter/INSTALL, maybe there's something wrong here or I'm misinterpreting it, so please check my code fix I've proven it myself.

before fix:
![1709636203433](https://github.com/vel21ripn/nDPI/assets/17486664/038c9979-b2bb-400d-9227-9399fac5a11a)
after fix:
![1709636260974](https://github.com/vel21ripn/nDPI/assets/17486664/85daa39d-aa1c-408c-af53-f7f37e809e6d)
![1709636308666](https://github.com/vel21ripn/nDPI/assets/17486664/3e4669ef-f9a8-4087-8437-86fc007a5e40)

thanks