### PR TITLE
fix commpile failed for patched kernel

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -2957,13 +2957,14 @@ static void __net_exit ndpi_net_exit(struct net *net)
 			      ARRAY_SIZE(nf_nat_ipv4_ops));
 	}
 
-
+#ifndef NF_CT_CUSTOM
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
 	net->ct.label_words = n->labels_word;
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
 	net->ct.labels_used--;
 #else
 	atomic_dec(&net->ct.labels_used);
+#endif
 #endif
 
 #if   LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)


### PR DESCRIPTION
I used patched kernel like this
![1710844820824](https://github.com/vel21ripn/nDPI/assets/17486664/3490579f-4a90-41de-a127-7e4dd63db27b)
and compile failed.


