### PR TITLE
Временное решение #202 и #176

### DIFF
--- a/ndpi-netfilter/src/Makefile
+++ b/ndpi-netfilter/src/Makefile
@@ -21,7 +21,8 @@ NDPI_PROTO_SRC := $(shell cd $(src) ; echo $(NDPI_PRO)/*.c)
 obj-m := xt_ndpi.o
 xt_ndpi-y := main.o ndpi_strcol.o ndpi_proc_parsers.o ndpi_proc_generic.o \
 		ndpi_proc_info.o  ndpi_proc_flow.o ndpi_proc_hostdef.o \
-		ndpi_proc_ipdef.o ../libre/regexp.o \
+		ndpi_proc_ipdef.o ndpi_proc_magic_ct.o \
+		../libre/regexp.o \
 		${NDPI_SRC}/lib/third_party/src/ndpi_md5.o \
 		${NDPI_SRC}/lib/third_party/src/ndpi_sha1.o \
 		${NDPI_SRC}/lib/third_party/src/ndpi_sha256.o \

--- a/ndpi-netfilter/src/ndpi_main_netfilter.h
+++ b/ndpi-netfilter/src/ndpi_main_netfilter.h
@@ -61,6 +61,7 @@ struct ndpi_net {
 #ifdef BT_ANNOUNCE
 				*pe_ann,
 #endif
+				*pe_magic_ct,
 				*pe_flow,
 				*pe_info,
 				*pe_proto,

--- a/ndpi-netfilter/src/ndpi_main_netfilter.h
+++ b/ndpi-netfilter/src/ndpi_main_netfilter.h
@@ -129,6 +129,7 @@ struct ndpi_net {
 	} mark[NDPI_NUM_BITS+1];
 	atomic64_t	protocols_cnt[NDPI_NUM_BITS+1];
 	NDPI_PROTOCOL_BITMASK protocols_bitmask;
+	unsigned short magic_ct;
 	char			ns_name[16];
 	u_int8_t debug_level[NDPI_NUM_BITS+1]; /* if defined NDPI_ENABLE_DEBUG_MESSAGES */
 };

--- a/ndpi-netfilter/src/ndpi_proc_magic_ct.c
+++ b/ndpi-netfilter/src/ndpi_proc_magic_ct.c
@@ -1,0 +1,63 @@
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/kernel.h>
+#include <linux/atomic.h>
+#include <linux/init.h>
+#include <linux/proc_fs.h>
+#include <linux/netfilter.h>
+
+#include "ndpi_main.h"
+
+#include "ndpi_main_common.h"
+#include "ndpi_strcol.h"
+#include "ndpi_main_netfilter.h"
+#include "ndpi_proc_magic_ct.h"
+
+int nmagic_ct_proc_open(struct inode *inode, struct file *file) {
+	return 0;
+}
+
+int nmagic_ct_proc_close(struct inode *inode, struct file *file) {
+	return 0;
+}
+
+ssize_t nmagic_ct_proc_read(struct file *file, char __user *buf,
+			size_t count, loff_t *ppos) {
+	struct ndpi_net *n = pde_data(file_inode(file));
+
+	char lbuf[6];
+	int len = 0;
+
+	if (*ppos > 0 || count < sizeof(lbuf)) {
+		return 0;
+	}
+
+	len += scnprintf(lbuf, sizeof(lbuf), "%hu\n", n->magic_ct);
+	if (copy_to_user(buf, lbuf, len)) {
+		return -EFAULT;
+	}
+
+	*ppos = len;
+	return len;
+}
+
+ssize_t nmagic_ct_proc_write(struct file *file, const char __user *buffer,
+			 size_t length, loff_t *loff) {
+	struct ndpi_net *n = pde_data(file_inode(file));
+
+	char lbuf[128];
+	unsigned int new_magic_ct;
+
+	if (*loff > 0 || length > sizeof(lbuf)) {
+		return -EFBIG;
+	}
+	if (copy_from_user(lbuf, buffer, length)) {
+		return -EFAULT;
+	}
+	if (kstrtouint(lbuf, 10, &new_magic_ct) != 0 || new_magic_ct > USHRT_MAX) {
+		return -EINVAL;
+	}
+
+	n->magic_ct = new_magic_ct;
+	return length;
+}

--- a/ndpi-netfilter/src/ndpi_proc_magic_ct.h
+++ b/ndpi-netfilter/src/ndpi_proc_magic_ct.h
@@ -1,0 +1,8 @@
+int nmagic_ct_proc_open(struct inode *inode, struct file *file); 
+
+int nmagic_ct_proc_close(struct inode *inode, struct file *file);
+
+ssize_t nmagic_ct_proc_read(struct file *file, char __user *buf,
+			size_t count, loff_t *ppos);
+ssize_t nmagic_ct_proc_write(struct file *file, const char __user *buffer,
+			 size_t length, loff_t *loff);


### PR DESCRIPTION
Временное решение от падения ядра при попытке синхронизации **conntrackd**.

Данные **nDPI** всё равно корректно не синхронизируются, потому что в **lable** хранится указатель на структуру.
Предлагаю оставить возможность для совместной работы **conntrackd** и **nDPI**.

Для этого заменил **MAGIC_CT** на параметр модуля, который можно задать разным на устройствах и тем самым избежать использование указателя в **label**, который пришёл с другого устройства.

Если задать **MAGIC_CT** задать 0, он сгенерируется случайным образом.

Так же сделал предупреждение в **dmesg**, что одинаковые **MAGIC_CT** приводит к падению.

Теперь **set_magic_ct** задаёт базовое значение для **MAGIC_CT**, чтобы оно было различным в разных **network namespace**.
Для стандартного **network namespace** используется базовое значение **MAGIC_CT**

Добавил **proc** файл для редактирования и чтения **magic_ct**.
Чтобы отредактировать **magic_ct** в нужном **network namespace** необходимо редактировать `/proc/net/xt_ndpi/magic_ct` из интересующего **namespace**.

Если редактировать **magic_ct** во время работающих соединений, то они зависнут и их необходимо будет закрыть. Поэтому лучше редактировать **magic_ct** до первого правила **ndpi-netfilter**.