### PR TITLE
Set kernel param magic_ct to zero

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -268,7 +268,7 @@ static inline int flow_have_info( struct nf_ct_ext_ndpi *c) {
 
 static ndpi_protocol_nf proto_null = {NDPI_PROTOCOL_UNKNOWN , NDPI_PROTOCOL_UNKNOWN};
 
-static unsigned short MAGIC_CT = 0xa55a;
+static unsigned short MAGIC_CT = 0x00;
 
 unsigned long int ndpi_flow_limit=10000000; // 4.3Gb
 unsigned long int ndpi_enable_flow=0;


### PR DESCRIPTION
Сделано для того, чтобы при каждой загрузке модуля без явного указания magic_ct базовый генерировался по новому.
Тем самым двум машинам не надо настраивать отдельно параметр magic_ct


