### PR TITLE
fix 64 integer division on 32 bit host systems

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6997,7 +6997,7 @@ void ndpi_free_flow_data(struct ndpi_flow_struct* flow) {
 }
 
 static inline uint32_t get_timestamp(uint64_t ts_l,uint32_t divisor) {
-#ifdef __KERNEL__
+#if defined(__KERNEL__) && !defined(CONFIG_64BIT)
 	do_div(ts_l,divisor);
 	return (uint32_t)ts_l;
 #else


### PR DESCRIPTION
on 32 bit systems like mips32 or armv7, gcc will generate unresolved symbols like __udivdi3. which is not available in the kernel

WARNING: "__udivdi3" [/home/seg/DEV/pb42/src/router/ndpi-netfilter/ndpi-netfilter/src/xt_ndpi.ko] undefined!

