### PR TITLE
Fix C89 compillation on Ubuntu 20.04

### DIFF
--- a/src/lib/protocols/ssdp.c
+++ b/src/lib/protocols/ssdp.c
@@ -223,12 +223,13 @@ static void ndpi_int_ssdp_add_connection(struct ndpi_detection_module_struct
 static void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = ndpi_get_packet_struct(ndpi_struct);
+  unsigned int i;
 	
   NDPI_LOG_DBG(ndpi_struct, "search ssdp\n");
   if (packet->udp != NULL) {
 
     if (packet->payload_packet_len >= 19) {
-      for (unsigned int i=0; i < sizeof(SSDP_METHODS)/sizeof(SSDP_METHODS[0]); i++) {
+      for (i=0; i < sizeof(SSDP_METHODS)/sizeof(SSDP_METHODS[0]); i++) {
         if(memcmp(packet->payload, SSDP_METHODS[i].detection_line, strlen(SSDP_METHODS[i].detection_line)) == 0) {
           if(ndpi_struct->cfg.ssdp_metadata_enabled) {
             flow->protos.ssdp.method = ndpi_malloc(strlen(SSDP_METHODS[i].detection_line) + 1);


### PR DESCRIPTION
The ssdp.c code uses variable declaration inside for loop, which is not permitted by c89 standard.

Fix by declaring the variable out of loop.

```
/home/user/nDPI/ndpi-netfilter/src/../../src/lib/protocols/ssdp.c: In function ‘ndpi_search_ssdp’: /home/user/nDPI/ndpi-netfilter/src/../../src/lib/protocols/ssdp.c:231:7: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  231 |       for (unsigned int i=0; i < sizeof(SSDP_METHODS)/sizeof(SSDP_METHODS[0]); i++) {
      |       ^~~
/home/user/nDPI/ndpi-netfilter/src/../../src/lib/protocols/ssdp.c:231:7: note: use option ‘-std=c99’, ‘-std=gnu99’, ‘-std=c11’ or ‘-std=gnu11’ to compile your code
```