### PR TITLE
src/main.c: Fix sleeping function called from atomic context in ndpi_net_exit

### DIFF
--- a/ndpi-netfilter/src/main.c
+++ b/ndpi-netfilter/src/main.c
@@ -3056,6 +3056,8 @@ static void __net_exit ndpi_net_exit(struct net *net)
 #endif
 #endif
 
+	write_unlock(&n->ndpi_busy);
+
 #if   LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)
 	struct nf_ct_iter_data iter_data = {
 		.net    = net,
@@ -3071,8 +3073,6 @@ static void __net_exit ndpi_net_exit(struct net *net)
 #else /* < 3.12 */
 	nf_ct_iterate_cleanup(net, ndpi_cleanup_flow, n);
 #endif
-
-	write_unlock(&n->ndpi_busy);
 
 	if(ndpi_enable_flow) {
 		while(ndpi_delete_acct(n,3) == -1)


### PR DESCRIPTION

When destroying a network namespace, the kernel invokes cleanup_net in a workqueue context. This triggers ndpi_net_exit(), which previously acquired a spinlock (write_lock(&n->ndpi_busy)) and then called nf_ct_iterate_cleanup_net() — a function that may sleep (it acquires a mutex internally).

This violated kernel locking rules: sleeping is forbidden in atomic context. The kernel (6.12.34), instrumented with sanitizers for syzkaller fuzzing, detected this bug when the xt_ndpi module was added to autostart:

    BUG: sleeping function called from invalid context at net/netfilter/nf_conntrack_core.c:2408
    in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 41, name: kworker/u16:1
    preempt_count: 1, expected: 0
    RCU nest depth: 0, expected: 0
    4 locks held by kworker/u16:1/41:
     #0: ffff8881003ac148 ((wq_completion)netns){+.+.}-{0:0}
     #1: ffff888100e37d80 (net_cleanup_work){+.+.}-{0:0}
     #2: ffffffff85fee2d0 (pernet_ops_rwsem){++++}-{3:3}
     #3: ffff888010ebc110 (&n->ndpi_busy){+++.}-{2:2}, at: ndpi_net_exit+0x119/0x930 [xt_ndpi]

    Call Trace:
     <TASK>
     __dump_stack lib/dump_stack.c:94 [inline]
     dump_stack_lvl+0xf0/0x120 lib/dump_stack.c:120
     __might_resched+0x354/0x560 kernel/sched/core.c:8678
     nf_ct_iterate_cleanup_net+0x7e/0x110 net/netfilter/nf_conntrack_core.c:2408
     ndpi_net_exit+0x155/0x930 [xt_ndpi]
     ops_exit_list+0xb3/0x180 net/core/net_namespace.c:173
     cleanup_net+0x54a/0x940 net/core/net_namespace.c:642
     process_one_work+0x902/0x1a30 kernel/workqueue.c:3229
     worker_thread+0x6c0/0xef0 kernel/workqueue.c:3391
     kthread+0x2b6/0x390 kernel/kthread.c:389
     ret_from_fork+0x44/0x70 arch/x86/kernel/process.c:152
     </TASK>

Move write_unlock(&n->ndpi_busy) before calling nf_ct_iterate_cleanup_net, so that the potentially sleeping function is called without holding any spinlocks.

Fixes: 4a25b1955039 ("Fix risk unidirectional_traffic.")