### PR TITLE
src/ndpi_strcol.c: Fix undefined behaviour caused by zero-length array in str_collect

### DIFF
--- a/ndpi-netfilter/src/ndpi_strcol.c
+++ b/ndpi-netfilter/src/ndpi_strcol.c
@@ -35,9 +35,10 @@ str_collect_t *c;
     if(!num_start)
 	    num_start =  128;
 
-    c = (str_collect_t *)kmalloc(sizeof(str_collect_t)-sizeof(c->s) + num_start + 1, GFP_KERNEL);
-    if(!c) 
-	return c;
+    /* allocate struct header + room for num_start chars + terminating NUL */
+    c = (str_collect_t *)kmalloc(sizeof(*c) + num_start + 1, GFP_KERNEL);
+    if (!c)
+        return NULL;
 
     c->max  = num_start;
     c->last = 0;

--- a/ndpi-netfilter/src/ndpi_strcol.h
+++ b/ndpi-netfilter/src/ndpi_strcol.h
@@ -4,7 +4,7 @@
 
 typedef struct str_collect {
 	size_t	 max,last;
-	char	 s[0];
+	char	 s[];
 } str_collect_t;
 
 typedef struct hosts_str {


### PR DESCRIPTION

Use a proper flexible array member (char s[]) for str_collect_t and simplify allocation to sizeof(*c) + num_start + 1.  The previous code declared `char s[0]` and indexed s[0], which is undefined behaviour and triggers UBSAN:

UBSAN: array-index-out-of-bounds in ../net/netfilter/xt_ndpi/ndpi-netfilter/src/ndpi_strcol.c:42:9 index 0 is out of range for type 'char [*]'
CPU: 0 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.34-alt-syz-fuzz+ #5 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.16.3-alt3 04/01/2014 Call Trace:
 <TASK>
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xf0/0x120 lib/dump_stack.c:120
 ubsan_epilogue+0xa/0x40 lib/ubsan.c:231
 __ubsan_handle_out_of_bounds+0x8e/0xa2 lib/ubsan.c:429
 str_collect_init+0x94/0xf0 net/netfilter/xt_ndpi/ndpi-netfilter/src/ndpi_strcol.c:44
 str_collect_add+0x321/0x450 net/netfilter/xt_ndpi/ndpi-netfilter/src/ndpi_strcol.c:148
 ndpi_init_host_ac_str net/netfilter/xt_ndpi/ndpi-netfilter/src/main.c:950 [inline]
 ndpi_init_host_ac net/netfilter/xt_ndpi/ndpi-netfilter/src/main.c:975 [inline]
 ndpi_net_init+0xfb2/0x2d90 net/netfilter/xt_ndpi/ndpi-netfilter/src/main.c:3229
 ops_init+0x1e2/0x630 net/core/net_namespace.c:139
 __register_pernet_operations net/core/net_namespace.c:1257 [inline]
 register_pernet_operations+0x34f/0x620 net/core/net_namespace.c:1333
 register_pernet_subsys+0x24/0x40 net/core/net_namespace.c:1374
 ndpi_mt_init+0x274/0x7b0 net/netfilter/xt_ndpi/ndpi-netfilter/src/main.c:3543
 do_one_initcall+0xf9/0x680 init/main.c:1269
 do_initcall_level init/main.c:1331 [inline]
 do_initcalls init/main.c:1347 [inline]
 do_basic_setup init/main.c:1366 [inline]
 kernel_init_freeable+0x647/0xc00 init/main.c:1580
 kernel_init+0x18/0x2e0 init/main.c:1469
 ret_from_fork+0x44/0x70 arch/x86/kernel/process.c:152
 ret_from_fork_asm+0x1a/0x30 arch/x86/entry/entry_64.S:244
 </TASK>


