### PR TITLE
ip_proto: deleting one port from a merged port range removes the whole range

### DIFF
--- a/ndpi-netfilter/src/ndpi_proc_parsers.c
+++ b/ndpi-netfilter/src/ndpi_proc_parsers.c
@@ -377,7 +377,7 @@ for(;i < end && np->start > tp->end; tp++,i++) {
 DD1
 if(i < end ) {
 	DD1;
-	if(np->start > tp->start && np->start < tp->end) {
+	if(np->start > tp->start && np->start <= tp->end) {
 	    tmp[k] = *tp;
 	    tmp[k].end = np->start-1;
 	    k++;
@@ -444,7 +444,8 @@ if(k <= 1) {
 		tmp[i].proto == np->proto) {
 		continue;	
 	    }
-	    if(i != l) tmp[l++] = tmp[i];
+	    if(i != l) tmp[l] = tmp[i];
+	    l++;
 	}
 	k = l;
     }

--- a/ndpi-netfilter/src/ndpi_proc_parsers.c
+++ b/ndpi-netfilter/src/ndpi_proc_parsers.c
@@ -457,6 +457,7 @@ if(k <= 1) {
 		i,tmp[i].start,tmp[i].end,tmp[i].proto,n);
 
 	if(tmp[l].proto != tmp[i].proto ||
+	   tmp[l].no_dpi != tmp[i].no_dpi ||
 	   tmp[l].end+1 != tmp[i].start) {
 	    l++;
 	    continue;


### PR DESCRIPTION
## Summary

When adjacent port rules for the same IP and protocol are written to `/proc/net/xt_ndpi/ip_proto`, they are merged into a single range (expected behavior). But deleting a single port from such a merged range removes the **entire** range instead of just the requested port.

## Steps to reproduce

```sh
echo '1.2.3.4 tcp:80:http' > /proc/net/xt_ndpi/ip_proto
echo '1.2.3.4 tcp:81:http' > /proc/net/xt_ndpi/ip_proto
cat /proc/net/xt_ndpi/ip_proto | grep tcp
# 1.2.3.4          tcp:80-81:http     <- merged, OK

echo '-1.2.3.4 tcp:81:http' > /proc/net/xt_ndpi/ip_proto
cat /proc/net/xt_ndpi/ip_proto | grep tcp
# (empty)                             <- BUG: tcp:80:http is gone too
```

Expected result after the delete: `1.2.3.4 tcp:80:http`.

## Root cause

Two bugs in `ndpi_port_range_update()` in `ndpi-netfilter/src/ndpi_proc_parsers.c`

1. The head-split condition uses a strict comparison:

   ```c
   if(np->start > tp->start && np->start < tp->end) {
   ```

   When the deleted port equals the end of an existing range (81 vs 80-81), `np->start < tp->end` is false, so the remaining head part (`80`) is silently dropped. The comparison should be `<=`.

   Note: this also affects the **add** path — writing `1.2.3.4 tcp:81:dns` over an existing `tcp:80-81:http` silently loses `tcp:80:http` as well.

2. The delete filter does not advance `l` when a kept element is already in place (`i == l`):

   ```c
   if(i != l) tmp[l++] = tmp[i];
   ```

   Such an element is later overwritten by the next shifted one. `l` must be incremented unconditionally for kept elements.

Because of (1), after deleting `tcp:81` from `tcp:80-81` the temporary list contains only the range being deleted, `k` ends up `<= 1`, and the `if(k <= 1) { if(!op) k = 0; }` branch drops everything.

## Proposed fix

```diff
--- a/ndpi-netfilter/src/ndpi_proc_parsers.c
+++ b/ndpi-netfilter/src/ndpi_proc_parsers.c
@@ ndpi_port_range_update()
- if(np->start > tp->start && np->start < tp->end) {
+ if(np->start > tp->start && np->start <= tp->end) {
   tmp[k] = *tp;
   tmp[k].end = np->start-1;
   k++;
@@ ndpi_port_range_update()  (delete filter under check_eq_proto)
-  if(i != l) tmp[l++] = tmp[i];
+  if(i != l) tmp[l] = tmp[i];
+  l++;
```

## Verification

I extracted `ndpi_port_range_update()` into a userspace harness and checked the following cases with the fix applied (all pass; the unpatched code fails case 2 with an empty result):

1. add 80 + add 81 → merged `80-81`
2. delete 81 from `80-81` → `80`
3. delete 80 from `80-81` → `81`
4. delete 85 from `80-90` → `80-84`, `86-90`
5. delete `80-81` from `80-81` → empty
6. add `81:dns` over `80-81:http` → `80:http`, `81:dns`
